### PR TITLE
Avoiding subprocess calls for clear. Use octal codes instead!

### DIFF
--- a/lib/game.py
+++ b/lib/game.py
@@ -119,7 +119,7 @@ class Game(offshoot.Pluggable):
                 if self.is_focused:
                     game_agent.on_game_frame(game_frame)
                 else:
-                    subprocess.call(["clear"])
+                    print("\033c")
                     print("PAUSED")
 
                     time.sleep(1)

--- a/lib/machine_learning/context_classification/context_classifiers/svm_context_classifier.py
+++ b/lib/machine_learning/context_classification/context_classifiers/svm_context_classifier.py
@@ -4,7 +4,6 @@ from lib.visual_debugger.visual_debugger import VisualDebugger
 
 import os
 import pickle
-import subprocess
 
 import skimage.io
 import skimage.transform
@@ -77,7 +76,7 @@ class SVMContextClassifier(ContextClassifier):
                     if predicted_class == current_label:
                         correct_sample_count += 1
 
-                    subprocess.call(["clear"])
+                    print("\033c")
                     print(f"SVM Accuracy: {correct_sample_count / sample_count}")
 
     def predict(self, input_frame):

--- a/plugins/BindingOfIsaacRebirthGameAgentPlugin/files/binding_of_isaac_rebirth_game_agent.py
+++ b/plugins/BindingOfIsaacRebirthGameAgentPlugin/files/binding_of_isaac_rebirth_game_agent.py
@@ -213,7 +213,7 @@ class BindingOfIsaacRebirthGameAgent(GameAgent):
                     is_checkpoint=True
                 )
 
-            subprocess.call(["clear"])
+            print("\033c")
 
             self.dqn.output_step_data(reward)
 
@@ -245,7 +245,7 @@ class BindingOfIsaacRebirthGameAgent(GameAgent):
             is_boss_dead = self._is_boss_dead(game_frame)
 
             if (self.game_state["health"] <= 0 and previous_health <= 0) or (is_boss_dead and previous_is_boss_dead):
-                subprocess.call(["clear"])
+                print("\033c")
                 timestamp = datetime.utcnow()
 
                 epsilon_delta = self.game_state["run_epsilon"] - self.dqn.epsilon_greedy_q_policy.epsilon
@@ -279,7 +279,7 @@ class BindingOfIsaacRebirthGameAgent(GameAgent):
 
                 if self.dqn.current_observe_step > self.dqn.observe_steps:
                     for i in range(50):
-                        subprocess.call(["clear"])
+                        print("\033c")
                         print(f"TRAINING ON MINI-BATCH: {i + 1}/50")
                         print(f"NEXT RUN: {self.game_state['current_run'] + 1} {'- AI RUN' if (self.game_state['current_run'] + 1) % 20 == 0 else ''}")
 

--- a/plugins/SuperHexagonGameAgentPlugin/files/super_hexagon_game_agent.py
+++ b/plugins/SuperHexagonGameAgentPlugin/files/super_hexagon_game_agent.py
@@ -8,8 +8,6 @@ import offshoot
 
 import time
 import json
-import subprocess
-
 from pprint import pprint
 
 from .helpers.frame_processing import *
@@ -163,7 +161,7 @@ class SuperHexagonGameAgent(GameAgent):
 
             score_averages = {duration: (np.max(scores or [0.0]), np.mean(scores or [0.0])) for duration, scores in self.game_state["scores"].items()}
 
-            subprocess.call(["clear"])
+            print("\033c")
 
             pprint(score_averages)
 


### PR DESCRIPTION
Hello. 

It really dazzles my eyes when I see invoking "clear" shell command from programming languages. It creates a shell, then it is running the clear command and result. Spawning a shell is unnecessary. We can send a code to output, that clears the visible buffer - which is \<ESC\>c (in other words 033c). 

I also deleted unused imports.