### PR TITLE
Steamproto argument support

### DIFF
--- a/lib/game_launchers/steam_game_launcher.py
+++ b/lib/game_launchers/steam_game_launcher.py
@@ -13,13 +13,20 @@ class SteamGameLauncher(GameLauncher):
 
     def launch(self, **kwargs):
         app_id = kwargs.get("app_id")
+        app_args = kwargs.get("app_args")
 
         if app_id is None:
             raise GameLauncherException("An 'app_id' kwarg is required...")
 
+        proto_string = f"steam://run/{app_id}"
+
+        if app_args is not None:
+            args_list = ["--{}={}".format(k, v) for k, v in app_args.items()]
+            proto_string += "/en/" + " ".join(args_list)
+
         if sys.platform in ["linux", "linux2"]:
-            subprocess.call(shlex.split(f"xdg-open steam://run/{app_id}"))
+            subprocess.call(shlex.split(f"xdg-open {proto_string}"))
         elif sys.platform == "darwin":
-            subprocess.call(shlex.split(f"open steam://run/{app_id}"))
+            subprocess.call(shlex.split(f"open {proto_string}"))
         elif sys.platform == "windows":
-            webbrowser.open(f"steam://run/{app_id}")
+            webbrowser.open(f"{proto_string}")


### PR DESCRIPTION
First off: I'm not entirely sure how a GitHub pull request that's based on another pending pull request should go. But here goes.  

This adds support to the Steam game launcher for defining arguments that will be passed to the defined Steam app.  
  
The documentation for the Steam protocol is outdated and lacking. See: [Valve Developer Wiki](https://developer.valvesoftware.com/wiki/Steam_browser_protocol). I was able to track down a [security research paper](http://revuln.com/files/ReVuln_Steam_Browser_Protocol_Insecurity.pdf) from a few years back that noted support for passing arguments through this protocol.  
  
The current use case for this feature is to load custom rooms in The Binding of Isaac. To load a custom room stored as `instapreview.xml` in BoI's root folder you would run this on the command line:  
  
    isaac-ng.exe --set-stage-type=0 --set-stage=1 --load-room=instapreview.xml  
  
Steam will show this notification before launching the game:  
  
![image](https://user-images.githubusercontent.com/3957791/27267053-63f4d3e4-546b-11e7-9585-c0a1ce9c3db3.png)
  

The equivalent game plugin file would look like this:  
  
```
class BindingOfIsaacRebirthGame(Game):

    def __init__(self, **kwargs):
        kwargs["platform"] = "steam"
        kwargs["app_id"] = "250900"
        
        kwargs["app_args"] = {
            "set-stage-type": 0,
            "set-stage": 1,
            "load-room": "instapreview.xml"
        }

        kwargs["window_name"] = "Binding of Isaac: Afterbirth"

        super().__init__(**kwargs)

```  
  
  
I'm unable to fully test this since the framework doesn't support Windows overall and I don't have access to an appropriate Linux box at the moment.
