### PR TITLE
Invoke python3 and add config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ plugins/
 
 build/
 dist/
+
+config/
+*.yml
+*.json
+/requirements.txt

--- a/serpent/bin/analytics_consumer
+++ b/serpent/bin/analytics_consumer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/serpent/bin/analytics_elasticsearch_wamp_component
+++ b/serpent/bin/analytics_elasticsearch_wamp_component
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/serpent/bin/analytics_wamp_component
+++ b/serpent/bin/analytics_wamp_component
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/serpent/bin/visual_debugger
+++ b/serpent/bin/visual_debugger
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/serpent/serpent.py
+++ b/serpent/serpent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 import shutil
@@ -139,17 +139,17 @@ def setup():
     print("Installing dependencies...")
 
     if sys.platform in ["linux", "linux2"]:
-        subprocess.call(shlex.split("pip install python-xlib"))
+        subprocess.call(shlex.split("python3 -m pip install python-xlib"))
     elif sys.platform == "darwin":
-        subprocess.call(shlex.split("pip install python-xlib pyobjc-framework-Quartz py-applescript"))
+        subprocess.call(shlex.split("python3 -m pip install python-xlib pyobjc-framework-Quartz py-applescript"))
     elif sys.platform == "win32":
         # Anaconda Packages
         subprocess.call(shlex.split("conda install numpy scipy scikit-image scikit-learn h5py -y"))
 
         # Kivy Dependencies
-        subprocess.call(shlex.split("pip install docutils pygments pypiwin32 kivy.deps.sdl2 kivy.deps.glew"))
+        subprocess.call(shlex.split("python3 -m pip install docutils pygments pypiwin32 kivy.deps.sdl2 kivy.deps.glew"))
 
-    subprocess.call(shlex.split("pip install -r requirements.txt"))
+    subprocess.call(shlex.split("python3 -m pip install -r requirements.txt"))
 
     # Create Dataset Directories
     os.makedirs(os.path.join(os.getcwd(), "datasets/collect_frames"), exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setuptools import setup
 
 import os


### PR DESCRIPTION
Even if `SerpentAI` was installed using `python3`, the tool invokes wrong python version when running `serpent setup` if environment `pip` points to `python2` causing dependency problems.

I changed shebang to point to `python3` in case `python` and `python3` invoke different python version so this would be in sync with correct python version when installing dependencies using `serpent setup` (which now uses `python3 -m pip` instead of `pip` to avoid chances of version mismatch).

Also updated .gitignore to exclude config files.