### PR TITLE
add in flag to drop into PDB on exception

### DIFF
--- a/serpent/serpent.py
+++ b/serpent/serpent.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 import shlex
 import time
+import traceback
+import pdb
 
 import offshoot
 
@@ -45,7 +47,21 @@ def execute():
             if command not in valid_commands:
                 raise Exception("'%s' is not a valid Serpent command." % command)
 
-            command_function_mapping[command](*sys.argv[2:])
+            if sys.argv[2] == "-d"  or sys.argv[2] == "--debug":
+                debug = True
+                sys.argv.pop(2)
+            else:
+                debug = False
+
+            try:
+                command_function_mapping[command](*sys.argv[2:])
+            except Exception as e:
+                if debug:
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    traceback.print_exception(exc_type, exc_value, exc_traceback)
+                    pdb.post_mortem(exc_traceback)
+                else:
+                    raise e
 
 
 def executable_help():

--- a/serpent/serpent.py
+++ b/serpent/serpent.py
@@ -47,7 +47,7 @@ def execute():
             if command not in valid_commands:
                 raise Exception("'%s' is not a valid Serpent command." % command)
 
-            if sys.argv[2] == "-d"  or sys.argv[2] == "--debug":
+            if len(sys.argv) > 2 and (sys.argv[2] == "-d"  or sys.argv[2] == "--debug"):
                 debug = True
                 sys.argv.pop(2)
             else:


### PR DESCRIPTION
This accomplishes #95, though it does require the flag to be entered directly after the command name. This probably isn't ideal, but a better solution would require a more general refactor of how the CLI works. I had though that would make more sense with #81, but it looks like that maybe isn't happening anymore.

PDB is built-in, so it should work cross-platform without issue, though I have no way of testing that.