### PR TITLE
Darwin tuple id

### DIFF
--- a/serpent/window_controllers/darwin_window_controller.py
+++ b/serpent/window_controllers/darwin_window_controller.py
@@ -1,5 +1,6 @@
 from serpent.window_controller import WindowController
 
+import re
 import applescript
 
 
@@ -13,34 +14,28 @@ class DarwinWindowController(WindowController):
             set visibleWindows to {}
             tell application "System Events"
                 repeat with this_app in (get processes whose background only is false) --get applications with 1+ window
-                    tell this_app
-                        set p_name to name
-                    end tell
-                    repeat with this_window in (get windows of this_app)
-                        tell this_window
-                            set w_name to name
-                        end tell
-                        set end of visibleWindows to {p_name, w_name}
-                    end repeat
+                    set end of visibleWindows to { (name of this_app), (get name of every window of this_app) }
                 end repeat
             end tell
             return visibleWindows
         ''').run()
-        for (p_name, w_name) in all_windows:
-            if w_name == name:
-                return (p_name, w_name)
-        return ["", ""]
+        for p_name, windows in all_windows:
+            for i, w_name in enumerate(windows):
+                if re.search(".*" + name + ".*", w_name):
+                    return (p_name, i + 1) # Windows are ordered by order of creations, it's a value that is fixed for the duration of the window's life
+        # If we didn't found the window, we fallback by testing if name is a process name
+        return [name, 1]
 
     def move_window(self, window_id, x, y):
         applescript.AppleScript(f'''
-            tell application "System Events" to tell window "{window_id[1]}" of process "{window_id[0]}"
+            tell application "System Events" to tell window {window_id[1]} of process "{window_id[0]}"
                 set position to { {x}, {y} }
             end tell
         ''').run()
 
     def resize_window(self, window_id, width, height):
         applescript.AppleScript(f'''
-            tell application "System Events" to tell window "{window_id[1]}" of process "{window_id[0]}"
+            tell application "System Events" to tell window {window_id[1]} of process "{window_id[0]}"
                 set size to { {width}, {height} }
             end tell
         ''').run()
@@ -53,7 +48,7 @@ class DarwinWindowController(WindowController):
         ''').run()
 
     def is_window_focused(self, window_id):
-        return self.get_focused_window_name() == window_id[1]
+        return window_id[0] == self.get_focused_window_name()
 
     def get_focused_window_name(self):
         focused_window_name = applescript.AppleScript('''
@@ -71,14 +66,14 @@ class DarwinWindowController(WindowController):
             return {frontAppName, windowTitle}
         ''').run()
 
-        return focused_window_name[1]
+        return focused_window_name[0]
 
     def get_window_geometry(self, window_id):
         geometry = dict()
 
         window_geometry = applescript.AppleScript(f'''
             tell application "System Events" to tell process "{window_id[0]}"
-                return get size of window "{window_id[1]}"
+                return get size of window {window_id[1]}
             end tell
         ''').run()
 
@@ -86,7 +81,7 @@ class DarwinWindowController(WindowController):
         geometry["height"] = int(window_geometry[1])
 
         window_information = applescript.AppleScript(f'''
-            tell application "System Events" to tell window "{window_id[1]}" of process "{window_id[0]}"
+            tell application "System Events" to tell window {window_id[1]} of process "{window_id[0]}"
                 return get position
             end tell
         ''').run()

--- a/serpent/window_controllers/darwin_window_controller.py
+++ b/serpent/window_controllers/darwin_window_controller.py
@@ -21,7 +21,7 @@ class DarwinWindowController(WindowController):
         ''').run()
         for p_name, windows in all_windows:
             for i, w_name in enumerate(windows):
-                if re.search(".*" + name + ".*", w_name):
+                if re.search(f"^{name}$", w_name):
                     return (p_name, i + 1) # Windows are ordered by order of creations, it's a value that is fixed for the duration of the window's life
         # If we didn't found the window, we fallback by testing if name is a process name
         return [name, 1]

--- a/serpent/window_controllers/darwin_window_controller.py
+++ b/serpent/window_controllers/darwin_window_controller.py
@@ -9,31 +9,34 @@ class DarwinWindowController(WindowController):
         pass
 
     def locate_window(self, name):
-        return name
+        tuple_id = name.split("::")
+        if len(tuple_id) == 1:
+            tuple_id = [tuple_id[0], "1"]
+        return tuple_id
 
     def move_window(self, window_id, x, y):
         applescript.AppleScript(f'''
-            tell application "System Events" to tell window 1 of process "{window_id}"
+            tell application "System Events" to tell window "{window_id[1]}" of process "{window_id[0]}"
                 set position to { {x}, {y} }
             end tell
         ''').run()
 
     def resize_window(self, window_id, width, height):
         applescript.AppleScript(f'''
-            tell application "System Events" to tell window 1 of process "{window_id}"
+            tell application "System Events" to tell window "{window_id[1]}" of process "{window_id[0]}"
                 set size to { {width}, {height} }
             end tell
         ''').run()
 
     def focus_window(self, window_id):
         applescript.AppleScript(f'''
-            tell application "System Events" to tell process "{window_id}"
+            tell application "System Events" to tell process "{window_id[0]}"
                 set frontmost to true
             end tell
         ''').run()
 
     def is_window_focused(self, window_id):
-        return self.get_focused_window_name() == window_id
+        return self.get_focused_window_name() == window_id[0]
 
     def get_focused_window_name(self):
         focused_window_id = applescript.AppleScript('''
@@ -48,8 +51,8 @@ class DarwinWindowController(WindowController):
         geometry = dict()
 
         window_geometry = applescript.AppleScript(f'''
-            tell application "System Events" to tell process "{window_id}"
-                return get size of window 1
+            tell application "System Events" to tell process "{window_id[0]}"
+                return get size of window "{window_id[1]}"
             end tell
         ''').run()
 
@@ -57,7 +60,7 @@ class DarwinWindowController(WindowController):
         geometry["height"] = int(window_geometry[1])
 
         window_information = applescript.AppleScript(f'''
-            tell application "System Events" to tell window 1 of process "{window_id}"
+            tell application "System Events" to tell window "{window_id[1]}" of process "{window_id[0]}"
                 return get position
             end tell
         ''').run()


### PR DESCRIPTION
Hello! ,

Thanks a lot for the work you've done so far. 

## Preface:
I've checked the `contribute.md` file and I fully understand your policy but I will definitely do some works to implements what I need for a personal project on top of your work. So I will probably send random pull request... As those pull requests might appear from nowhere, I'm not expecting you to merge them fast or even at all. BUT if my pull request annoys you, feel free to tell me to stop  👍🏻

## Back to the work done:
I needed the capacity to have a little bit more control over the window_controller on OSX. Precisely, I wanted to select a precise window of an app (some emulator creates multiple windows).

So I changed the `locate` function on OSX for a tuple (str:appName, int:windowNumber) which can be  considered an identifier (windowNumber is 1-indexed).
OSX keeps an array of created windows for every process, they are added in the order of their creations. As long as one doesn't delete a window, the indices can be considered static. 
In the different usecases of SerpentAI, this is probably fine.

What do you think?

*PS: I'm not a OSX guru at all, so feel free to criticise.*