### PR TITLE
Simplify the workflow to capture frames, leveraging the existing game_frame_limiter

### DIFF
--- a/serpent/game.py
+++ b/serpent/game.py
@@ -66,7 +66,7 @@ class Game(offshoot.Pluggable):
         self.frame_height = None
         self.frame_channels = 3
 
-        self.game_frame_limiter = GameFrameLimiter(fps=self.config.get("fps", 30))
+        self.game_frame_limiter = GameFrameLimiter(fps=kwargs.get("fps", self.config.get("fps", 30)))
 
         self.api_class = None
         self.api_instance = None

--- a/serpent/game_agent.py
+++ b/serpent/game_agent.py
@@ -137,8 +137,6 @@ class GameAgent(offshoot.Pluggable):
         serpent.utilities.clear_terminal()
         print(f"Collected Frame #{self.collected_frame_count}")
 
-        time.sleep(kwargs.get("interval") or self.config.get("collect_frames_interval") or 1)
-
     def handle_collect_frame_regions(self, game_frame, **kwargs):
         region = kwargs.get("region")
 
@@ -149,11 +147,8 @@ class GameAgent(offshoot.Pluggable):
         serpent.utilities.clear_terminal()
         print(f"Collected Frame #{self.collected_frame_count} for Region: {region}")
 
-        time.sleep(kwargs.get("interval") or self.config.get("collect_frames_interval") or 1)
-
     def handle_collect_frames_for_context(self, game_frame, **kwargs):
         context = kwargs.get("context") or config["frame_handlers"]["COLLECT_FRAMES_FOR_CONTEXT"]["context"]
-        interval = kwargs.get("interval") or config["frame_handlers"]["COLLECT_FRAMES_FOR_CONTEXT"]["interval"]
 
         self.game_frames.append(game_frame)
 
@@ -161,8 +156,6 @@ class GameAgent(offshoot.Pluggable):
 
         serpent.utilities.clear_terminal()
         print(f"Collected Frame #{self.collected_frame_count} for Context: {context}")
-
-        time.sleep(interval)
 
     def on_collect_frames_pause(self, **kwargs):
         for i, game_frame in enumerate(self.game_frames):

--- a/serpent/game_frame_limiter.py
+++ b/serpent/game_frame_limiter.py
@@ -19,5 +19,6 @@ class GameFrameLimiter:
         if remaining_frame_time > 0:
             time.sleep(remaining_frame_time)
 
-    def benchmark(self):
-        pass
+    def benchmark(self, message=""):
+        duration = (datetime.utcnow() - self.started_at).microseconds / 1000000
+        print("%s %f" % (message, duration))

--- a/serpent/serpent.py
+++ b/serpent/serpent.py
@@ -261,7 +261,7 @@ def capture(capture_type, game_name, interval=1, extra=None):
     if game_class is None:
         raise Exception(f"Game '{game_name}' wasn't found. Make sure the plugin is installed.")
 
-    game = game_class()
+    game = game_class(fps=1./float(interval))
 
     game.launch(dry_run=True)
 


### PR DESCRIPTION
Hi @nbrochu!

I was playing with the capture frame system and I was having a slower rate/interval than the one I entered. After some digging, I've discovered many sleep calls that were interfering with the main loop. I thought they could be removed by leveraging the existing game_frame_limiter class.

Note: It's still not really following the real-time rate because of the function call `is_window_focused` on the main loop, depending on the underlying OS, it introduces more or less some lags. But this part doesn't seem easily improvable.

