### PR TITLE
Block the window search until there are results

### DIFF
--- a/serpent/window_controllers/linux_window_controller.py
+++ b/serpent/window_controllers/linux_window_controller.py
@@ -12,7 +12,7 @@ class LinuxWindowController(WindowController):
         pass
 
     def locate_window(self, name):
-        return subprocess.check_output(shlex.split(f"xdotool search --onlyvisible --name \"^{name}$\"")).decode("utf-8").strip()
+        return subprocess.check_output(shlex.split(f"xdotool search --sync --onlyvisible --name \"^{name}$\"")).decode("utf-8").strip()
 
     def move_window(self, window_id, x, y):
         subprocess.call(shlex.split(f"xdotool windowmove {window_id} {x} {y}"))


### PR DESCRIPTION
this prevents
`subprocess.CalledProcessError: Command '['xdotool', 'search', '--onlyvisible', '--name', '^WINDOW TITLE$']' returned non-zero exit status 1.`
errors on my system when launching games